### PR TITLE
feat: add JS api

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,36 @@ line.render_notebook()
 line.render_jupyter_lab()
 ```
 
+#### **use JavaScript callback**
+
+```py
+from pyg2plot import Plot, JS
+
+line = Plot("Line")
+
+line.set_options({
+  "height": 400, # set a default height in jupyter preview
+  "data": [
+    { "year": "1991", "value": 3 },
+    { "year": "1992", "value": 4 },
+    { "year": "1993", "value": 3.5 },
+    { "year": "1994", "value": 5 },
+    { "year": "1995", "value": 4.9 },
+    { "year": "1996", "value": 6 },
+    { "year": "1997", "value": 7 },
+    { "year": "1998", "value": 9 },
+    { "year": "1999", "value": 13 },
+  ],
+  "xField": "year",
+  "yField": "value",
+  "lineStye": JS('''function() {
+    return { stroke: 'red' }; 
+  }''')
+})
+```
+
+Use `JS` API, you can use JavaScript syntax for callback.
+
 
 ## API
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -84,6 +84,36 @@ line.render_notebook()
 line.render_jupyter_lab()
 ```
 
+#### **使用 JavaScript 回调**
+
+```py
+from pyg2plot import Plot, JS
+
+line = Plot("Line")
+
+line.set_options({
+  "height": 400, # set a default height in jupyter preview
+  "data": [
+    { "year": "1991", "value": 3 },
+    { "year": "1992", "value": 4 },
+    { "year": "1993", "value": 3.5 },
+    { "year": "1994", "value": 5 },
+    { "year": "1995", "value": 4.9 },
+    { "year": "1996", "value": 6 },
+    { "year": "1997", "value": 7 },
+    { "year": "1998", "value": 9 },
+    { "year": "1999", "value": 13 },
+  ],
+  "xField": "year",
+  "yField": "value",
+  "lineStye": JS('''function() {
+    return { stroke: 'red' }; 
+  }''')
+})
+```
+
+使用 `JS` 方法，你可以创建一个 JavaScript 的代码片段去处理各种回调方法属性。
+
 
 ## API
 

--- a/pyg2plot/helper/code.py
+++ b/pyg2plot/helper/code.py
@@ -3,10 +3,12 @@ import simplejson
 import re
 import datetime
 
+# no JSON.stringigy in Python
+SEP = "!!-_-____-_-!!"
 
 class JS:
     def __init__(self, js_code: str):
-        self.js_code = js_code
+        self.js_code = "%s%s%s" % (SEP, js_code, SEP)
 
     def replace(self, pattern: str, repl: str):
         self.js_code = re.sub(pattern, repl, self.js_code)
@@ -22,4 +24,8 @@ def _json_dump_default(o: object):
 
 
 def json_dump_to_js(options: object):
-    return simplejson.dumps(options, indent=2, default=_json_dump_default, ignore_nan=True)
+    return re.sub(
+        '"?%s"?' % SEP,
+        "",
+        simplejson.dumps(options, indent=2, default=_json_dump_default, ignore_nan=True)
+    )

--- a/pyg2plot/meta.py
+++ b/pyg2plot/meta.py
@@ -6,5 +6,5 @@ Created on 2021-01-14
 > pkg meta information
 '''
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"
 __author__ = "hustcc"


### PR DESCRIPTION
```py
from pyg2plot import Plot, JS

line = Plot("Line")
line.set_options({
  "height": 400, # set a default height in jupyter preview
  "data": [
    { "year": "1991", "value": 3 },
    { "year": "1992", "value": 4 },
    { "year": "1993", "value": 3.5 },
    { "year": "1994", "value": 5 },
    { "year": "1995", "value": 4.9 },
    { "year": "1996", "value": 6 },
    { "year": "1997", "value": 7 },
    { "year": "1998", "value": 9 },
    { "year": "1999", "value": 13 },
  ],
  "xField": "year",
  "yField": "value",
  "lineStye": JS('''function() {
    return { stroke: 'red' }; 
  }''')
})
```